### PR TITLE
Avoid to use internal third-party on FreeBSD

### DIFF
--- a/mybee-qt.pro
+++ b/mybee-qt.pro
@@ -1,11 +1,16 @@
 TEMPLATE = subdirs
-SUBDIRS = zlib-ng libjpeg-turbo libssh freerdp2 vnc src
+
+freebsd {
+    SUBDIRS = src
+} else {
+    SUBDIRS = zlib-ng libjpeg-turbo libssh freerdp2 vnc src
+    libssh.depends = zlib-ng
+    freerdp2.depends = zlib-ng libjpeg-turbo
+    vnc.depends = zlib-ng libjpeg-turbo
+    src.depends = libssh freerdp2 vnc
+}
 
 #CONFIG += ordered
-libssh.depends = zlib-ng
-freerdp2.depends = zlib-ng libjpeg-turbo
-vnc.depends = zlib-ng libjpeg-turbo
-src.depends = libssh freerdp2 vnc
 
 DISTFILES += \
     APP_VERSION \

--- a/src/src.pro
+++ b/src/src.pro
@@ -15,7 +15,12 @@ CONFIG += c++17 release
 CONFIG += file_copies lrelease embed_translations
 
 DEFINES += LIBSSH_STATIC SSH_NO_CPP_EXCEPTIONS
-INCLUDEPATH += ../include ../include/freerdp2 ../include/winpr2
+
+freebsd {
+    INCLUDEPATH += /usr/local/include/freerdp2 /usr/local/include/freerdp2/freerdp/client  /usr/local/include/winpr2 ../include ../include/freerdp2 ../include/winpr2
+} else {
+    INCLUDEPATH += ../include ../include/freerdp2 ../include/winpr2
+}
 
 !isEmpty(OPENSSL_ROOT_DIR) {
     INCLUDEPATH += $$clean_path($${OPENSSL_ROOT_DIR}/include)
@@ -63,10 +68,14 @@ windows {
 
 } else { # any other unix & linux
 
-    LIBS += ../lib/libssh.a ../lib/libvncclient.a
-    LIBS += ../lib/libfreerdp-client2.a ../lib/freerdp2/lib*.a ../lib/libfreerdp2.a ../lib/libwinpr2.a
-    LIBS += ../lib/libturbojpeg.a ../lib/libz.a
-    LIBS += -lssl -lcrypto -ldl -lutil
+    freebsd {
+        LIBS += -lssl -lcrypto -ldl -lutil -lturbojpeg -lz-ng -lssh -lfreerdp-client2 -lfreerdp2 -lwinpr2 -lvncclient -lz
+    } else {
+        LIBS += ../lib/libssh.a ../lib/libvncclient.a
+        LIBS += ../lib/libfreerdp-client2.a ../lib/freerdp2/lib*.a ../lib/libfreerdp2.a ../lib/libwinpr2.a
+        LIBS += ../lib/libturbojpeg.a ../lib/libz.a
+        LIBS += -lssl -lcrypto -ldl -lutil
+    }
 }
 
 SOURCES += \


### PR DESCRIPTION
On FreeBSD, all third-party included in mybee-qt are available thanks to ports/pkg system.

The PR merges [ports patches](https://github.com/freebsd/freebsd-ports/tree/fa30cdf1ce5c5ecc04ef10efdf2fd9cb0059e821/deskutils/mybee-qt/files) from @krionbsd into qmake pro files.